### PR TITLE
:sparkles: feat: aplica alto contraste global no app do viajante

### DIFF
--- a/TP4/lib/app/porto_certo_app.dart
+++ b/TP4/lib/app/porto_certo_app.dart
@@ -225,9 +225,17 @@ class _PortoCertoShellState extends State<PortoCertoShell> {
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedSwitcher(
+    final screen = AnimatedSwitcher(
       duration: const Duration(milliseconds: 220),
       child: KeyedSubtree(key: ValueKey(_screen), child: _buildScreen()),
+    );
+
+    if (!_highContrast) return screen;
+
+    final mediaQuery = MediaQuery.of(context);
+    return MediaQuery(
+      data: mediaQuery.copyWith(boldText: true, highContrast: true),
+      child: Theme(data: AppTheme.light(highContrast: true), child: screen),
     );
   }
 

--- a/TP4/lib/app/porto_certo_app.dart
+++ b/TP4/lib/app/porto_certo_app.dart
@@ -60,6 +60,7 @@ class _PortoCertoShellState extends State<PortoCertoShell> {
   void initState() {
     super.initState();
     _loadFavorites();
+    _loadHighContrastPreference();
   }
 
   @override
@@ -70,7 +71,35 @@ class _PortoCertoShellState extends State<PortoCertoShell> {
   }
 
   void _nav(AppScreen screen) {
-    setState(() => _screen = screen);
+    setState(() {
+      _screen = screen;
+      if (screen == AppScreen.login && AuthService().currentUser == null) {
+        _highContrast = false;
+      }
+    });
+    if (screen == AppScreen.home) {
+      _loadHighContrastPreference();
+    }
+  }
+
+  Future<void> _loadHighContrastPreference() async {
+    try {
+      final user = AuthService().currentUser;
+      if (user == null) return;
+
+      final idToken = await user.getIdToken();
+      if (idToken == null || idToken.isEmpty) return;
+
+      final profile = await _travelerRepository.fetchMe(
+        firebaseUid: user.uid,
+        idToken: idToken,
+        email: user.email,
+      );
+      if (!mounted) return;
+      _applyHighContrast(profile.highContrast);
+    } catch (_) {
+      // A preferência será carregada novamente ao entrar ou abrir o perfil.
+    }
   }
 
   void _toggleFavorite(String tripId) {

--- a/TP4/lib/core/theme/app_theme.dart
+++ b/TP4/lib/core/theme/app_theme.dart
@@ -3,80 +3,104 @@ import 'package:flutter/material.dart';
 import 'app_colors.dart';
 
 class AppTheme {
-  static ThemeData light() {
+  static ThemeData light({bool highContrast = false}) {
     final base = ThemeData(
       colorScheme: ColorScheme.fromSeed(
-        seedColor: AppColors.primary,
-        primary: AppColors.primary,
-        secondary: AppColors.secondary,
-        surface: AppColors.surface,
+        seedColor: highContrast ? Colors.yellow : AppColors.primary,
+        primary: highContrast ? Colors.yellow : AppColors.primary,
+        secondary: highContrast ? Colors.white : AppColors.secondary,
+        surface: highContrast ? Colors.black : AppColors.surface,
+        brightness: highContrast ? Brightness.dark : Brightness.light,
       ),
       useMaterial3: true,
-      scaffoldBackgroundColor: AppColors.surface,
+      scaffoldBackgroundColor: highContrast ? Colors.black : AppColors.surface,
       fontFamily: 'Roboto',
     );
+
+    final textColor = highContrast ? Colors.white : const Color(0xFF1F2937);
+    final displayColor = highContrast ? Colors.yellow : const Color(0xFF111827);
 
     return base.copyWith(
       textTheme: base.textTheme
           .apply(
-            bodyColor: const Color(0xFF1F2937),
-            displayColor: const Color(0xFF111827),
+            bodyColor: textColor,
+            displayColor: displayColor,
             fontFamily: 'Roboto',
           )
           .copyWith(
             titleLarge: base.textTheme.titleLarge?.copyWith(
               fontFamily: 'Montserrat',
-              fontWeight: FontWeight.w800,
+              fontWeight: FontWeight.w900,
+              color: displayColor,
             ),
             titleMedium: base.textTheme.titleMedium?.copyWith(
               fontFamily: 'Montserrat',
-              fontWeight: FontWeight.w800,
+              fontWeight: FontWeight.w900,
+              color: displayColor,
             ),
             titleSmall: base.textTheme.titleSmall?.copyWith(
               fontFamily: 'Montserrat',
-              fontWeight: FontWeight.w700,
+              fontWeight: FontWeight.w800,
+              color: displayColor,
             ),
           ),
-      appBarTheme: const AppBarTheme(
-        backgroundColor: AppColors.card,
-        foregroundColor: Color(0xFF111827),
+      appBarTheme: AppBarTheme(
+        backgroundColor: highContrast ? Colors.black : AppColors.card,
+        foregroundColor: highContrast ? Colors.yellow : const Color(0xFF111827),
         elevation: 0,
         centerTitle: false,
         surfaceTintColor: Colors.transparent,
       ),
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
-        fillColor: Colors.white,
+        fillColor: highContrast ? Colors.black : Colors.white,
+        labelStyle: TextStyle(
+          color: highContrast ? Colors.yellow : AppColors.muted,
+        ),
+        hintStyle: TextStyle(
+          color: highContrast ? Colors.white70 : AppColors.muted,
+        ),
         contentPadding: const EdgeInsets.symmetric(
           horizontal: 16,
           vertical: 14,
         ),
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(18),
-          borderSide: const BorderSide(color: AppColors.border),
+          borderSide: BorderSide(
+            color: highContrast ? Colors.yellow : AppColors.border,
+            width: highContrast ? 2 : 1,
+          ),
         ),
         enabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(18),
-          borderSide: const BorderSide(color: AppColors.border),
+          borderSide: BorderSide(
+            color: highContrast ? Colors.yellow : AppColors.border,
+            width: highContrast ? 2 : 1,
+          ),
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(18),
-          borderSide: const BorderSide(color: AppColors.primary, width: 1.6),
+          borderSide: BorderSide(
+            color: highContrast ? Colors.yellow : AppColors.primary,
+            width: 2,
+          ),
         ),
       ),
-      bottomNavigationBarTheme: const BottomNavigationBarThemeData(
-        backgroundColor: Colors.white,
-        selectedItemColor: AppColors.primary,
-        unselectedItemColor: Color(0xFF9CA3AF),
+      bottomNavigationBarTheme: BottomNavigationBarThemeData(
+        backgroundColor: highContrast ? Colors.black : Colors.white,
+        selectedItemColor: highContrast ? Colors.yellow : AppColors.primary,
+        unselectedItemColor: highContrast
+            ? Colors.white70
+            : const Color(0xFF9CA3AF),
         type: BottomNavigationBarType.fixed,
         elevation: 16,
-        selectedLabelStyle: TextStyle(
+        selectedLabelStyle: const TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w800,
+        ),
+        unselectedLabelStyle: const TextStyle(
           fontSize: 11,
           fontWeight: FontWeight.w700,
-        ),
-        unselectedLabelStyle: TextStyle(
-          fontSize: 11,
-          fontWeight: FontWeight.w600,
         ),
       ),
     );

--- a/TP4/lib/core/theme/app_theme.dart
+++ b/TP4/lib/core/theme/app_theme.dart
@@ -4,14 +4,28 @@ import 'app_colors.dart';
 
 class AppTheme {
   static ThemeData light({bool highContrast = false}) {
+    final colorScheme =
+        ColorScheme.fromSeed(
+          seedColor: highContrast ? Colors.yellow : AppColors.primary,
+          primary: highContrast ? Colors.yellow : AppColors.primary,
+          secondary: highContrast ? Colors.yellow : AppColors.secondary,
+          surface: highContrast ? Colors.black : AppColors.surface,
+          brightness: highContrast ? Brightness.dark : Brightness.light,
+        ).copyWith(
+          onPrimary: highContrast ? Colors.black : null,
+          onSecondary: highContrast ? Colors.black : null,
+          onSurface: highContrast ? Colors.white : null,
+          onSurfaceVariant: highContrast ? Colors.white70 : null,
+          outline: highContrast ? Colors.yellow : AppColors.border,
+          outlineVariant: highContrast ? Colors.yellow : AppColors.border,
+          surfaceContainer: highContrast ? Colors.black : Colors.white,
+          surfaceContainerHighest: highContrast
+              ? const Color(0xFF171717)
+              : const Color(0xFFF3F4F6),
+        );
+
     final base = ThemeData(
-      colorScheme: ColorScheme.fromSeed(
-        seedColor: highContrast ? Colors.yellow : AppColors.primary,
-        primary: highContrast ? Colors.yellow : AppColors.primary,
-        secondary: highContrast ? Colors.white : AppColors.secondary,
-        surface: highContrast ? Colors.black : AppColors.surface,
-        brightness: highContrast ? Brightness.dark : Brightness.light,
-      ),
+      colorScheme: colorScheme,
       useMaterial3: true,
       scaffoldBackgroundColor: highContrast ? Colors.black : AppColors.surface,
       fontFamily: 'Roboto',
@@ -50,6 +64,21 @@ class AppTheme {
         elevation: 0,
         centerTitle: false,
         surfaceTintColor: Colors.transparent,
+      ),
+      cardTheme: CardThemeData(
+        color: highContrast ? Colors.black : Colors.white,
+        surfaceTintColor: Colors.transparent,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(24),
+          side: BorderSide(
+            color: highContrast ? Colors.yellow : Colors.transparent,
+            width: highContrast ? 2 : 0,
+          ),
+        ),
+      ),
+      dividerColor: highContrast ? Colors.yellow : AppColors.border,
+      iconTheme: IconThemeData(
+        color: highContrast ? Colors.yellow : const Color(0xFF374151),
       ),
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
@@ -102,6 +131,37 @@ class AppTheme {
           fontSize: 11,
           fontWeight: FontWeight.w700,
         ),
+      ),
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          foregroundColor: highContrast ? Colors.yellow : AppColors.primary,
+        ),
+      ),
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: OutlinedButton.styleFrom(
+          foregroundColor: highContrast ? Colors.yellow : AppColors.primary,
+          side: BorderSide(
+            color: highContrast ? Colors.yellow : AppColors.primary,
+            width: highContrast ? 2 : 1,
+          ),
+        ),
+      ),
+      switchTheme: SwitchThemeData(
+        thumbColor: WidgetStateProperty.resolveWith(
+          (states) => states.contains(WidgetState.selected)
+              ? (highContrast ? Colors.black : Colors.white)
+              : null,
+        ),
+        trackColor: WidgetStateProperty.resolveWith(
+          (states) => states.contains(WidgetState.selected)
+              ? (highContrast ? Colors.yellow : AppColors.primary)
+              : null,
+        ),
+      ),
+      sliderTheme: base.sliderTheme.copyWith(
+        activeTrackColor: highContrast ? Colors.yellow : AppColors.primary,
+        thumbColor: highContrast ? Colors.yellow : AppColors.primary,
+        inactiveTrackColor: highContrast ? Colors.white54 : null,
       ),
     );
   }

--- a/TP4/lib/core/widgets/app_header.dart
+++ b/TP4/lib/core/widgets/app_header.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 import '../../app/app_routes.dart';
 import '../../app/app_state.dart';
-import '../theme/app_colors.dart';
 
 class AppHeader extends StatelessWidget {
   const AppHeader({
@@ -22,10 +21,12 @@ class AppHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+
     return DecoratedBox(
-      decoration: const BoxDecoration(
-        color: Colors.white,
-        border: Border(bottom: BorderSide(color: AppColors.border)),
+      decoration: BoxDecoration(
+        color: colors.surfaceContainer,
+        border: Border(bottom: BorderSide(color: colors.outline)),
       ),
       child: SafeArea(
         bottom: false,
@@ -55,8 +56,8 @@ class AppHeader extends StatelessWidget {
                         padding: const EdgeInsets.only(top: 2),
                         child: Text(
                           subtitle!,
-                          style: const TextStyle(
-                            color: AppColors.muted,
+                          style: TextStyle(
+                            color: colors.onSurfaceVariant,
                             fontSize: 12,
                             fontWeight: FontWeight.w500,
                           ),
@@ -82,8 +83,10 @@ class _CircleIconButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+
     return Material(
-      color: const Color(0xFFF3F4F6),
+      color: colors.surfaceContainerHighest,
       borderRadius: BorderRadius.circular(999),
       child: InkWell(
         onTap: onTap,
@@ -91,7 +94,7 @@ class _CircleIconButton extends StatelessWidget {
         child: SizedBox(
           width: 36,
           height: 36,
-          child: Icon(icon, size: 22, color: const Color(0xFF374151)),
+          child: Icon(icon, size: 22, color: colors.onSurface),
         ),
       ),
     );

--- a/TP4/lib/core/widgets/network_image_box.dart
+++ b/TP4/lib/core/widgets/network_image_box.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 
-import '../theme/app_colors.dart';
-
 class NetworkImageBox extends StatelessWidget {
   const NetworkImageBox({
     super.key,
@@ -28,13 +26,14 @@ class NetworkImageBox extends StatelessWidget {
         width: width,
         fit: fit,
         errorBuilder: (context, error, stackTrace) {
+          final colors = Theme.of(context).colorScheme;
           return Container(
             height: height,
             width: width,
-            color: AppColors.primary.withValues(alpha: 0.10),
-            child: const Icon(
+            color: colors.primary.withValues(alpha: 0.10),
+            child: Icon(
               Icons.directions_boat_filled_outlined,
-              color: AppColors.primary,
+              color: colors.primary,
               size: 34,
             ),
           );

--- a/TP4/lib/core/widgets/pc_button.dart
+++ b/TP4/lib/core/widgets/pc_button.dart
@@ -27,7 +27,7 @@ class PcButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final enabled = onPressed != null && !loading;
-    final style = _styleFor(variant);
+    final style = _styleFor(context, variant);
     final foreground = enabled
         ? style.foreground
         : style.foreground.withValues(alpha: 0.45);
@@ -92,7 +92,30 @@ class PcButton extends StatelessWidget {
     );
   }
 
-  _ButtonStyle _styleFor(PcButtonVariant variant) {
+  _ButtonStyle _styleFor(BuildContext context, PcButtonVariant variant) {
+    final theme = Theme.of(context);
+    if (theme.brightness == Brightness.dark) {
+      final colors = theme.colorScheme;
+      return switch (variant) {
+        PcButtonVariant.primary ||
+        PcButtonVariant.secondary ||
+        PcButtonVariant.teal => _ButtonStyle(
+          colors.primary,
+          colors.onPrimary,
+          colors.primary,
+          2,
+        ),
+        PcButtonVariant.outline ||
+        PcButtonVariant.ghost ||
+        PcButtonVariant.danger => _ButtonStyle(
+          colors.surface,
+          colors.primary,
+          colors.primary,
+          2,
+        ),
+      };
+    }
+
     return switch (variant) {
       PcButtonVariant.primary => const _ButtonStyle(
         AppColors.primary,

--- a/TP4/lib/core/widgets/pc_card.dart
+++ b/TP4/lib/core/widgets/pc_card.dart
@@ -16,19 +16,26 @@ class PcCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+    final highContrast = theme.brightness == Brightness.dark;
+
     return Container(
       margin: margin,
       padding: padding,
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: colors.surfaceContainer,
         borderRadius: BorderRadius.circular(24),
-        border: border,
+        border:
+            border ??
+            (highContrast ? Border.all(color: colors.outline, width: 2) : null),
         boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.045),
-            blurRadius: 18,
-            offset: const Offset(0, 8),
-          ),
+          if (!highContrast)
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.045),
+              blurRadius: 18,
+              offset: const Offset(0, 8),
+            ),
         ],
       ),
       child: child,

--- a/TP4/lib/core/widgets/pc_chip.dart
+++ b/TP4/lib/core/widgets/pc_chip.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 
-import '../theme/app_colors.dart';
-
 class PcChip extends StatelessWidget {
   const PcChip({
     super.key,
@@ -16,11 +14,13 @@ class PcChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+
     return Material(
-      color: active ? AppColors.primary : Colors.white,
+      color: active ? colors.primary : colors.surfaceContainer,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(999),
-        side: BorderSide(color: active ? AppColors.primary : AppColors.border),
+        side: BorderSide(color: colors.outline),
       ),
       child: InkWell(
         onTap: onTap,
@@ -30,7 +30,7 @@ class PcChip extends StatelessWidget {
           child: Text(
             label,
             style: TextStyle(
-              color: active ? Colors.white : const Color(0xFF4B5563),
+              color: active ? colors.onPrimary : colors.onSurface,
               fontWeight: FontWeight.w800,
               fontSize: 12,
             ),

--- a/TP4/lib/core/widgets/pc_text_field.dart
+++ b/TP4/lib/core/widgets/pc_text_field.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 
-import '../theme/app_colors.dart';
-
 class PcTextField extends StatelessWidget {
   const PcTextField({
     super.key,
@@ -34,6 +32,8 @@ class PcTextField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -41,8 +41,8 @@ class PcTextField extends StatelessWidget {
           padding: const EdgeInsets.only(left: 2, bottom: 7),
           child: Text(
             label.toUpperCase(),
-            style: const TextStyle(
-              color: AppColors.muted,
+            style: TextStyle(
+              color: colors.onSurfaceVariant,
               fontSize: 11,
               fontWeight: FontWeight.w800,
               letterSpacing: 0.7,
@@ -63,7 +63,7 @@ class PcTextField extends StatelessWidget {
             errorText: errorText,
             prefixIcon: icon == null
                 ? null
-                : Icon(icon, color: AppColors.muted, size: 19),
+                : Icon(icon, color: colors.onSurfaceVariant, size: 19),
             suffixIcon: suffix,
           ),
         ),

--- a/TP4/lib/core/widgets/progress_steps.dart
+++ b/TP4/lib/core/widgets/progress_steps.dart
@@ -10,6 +10,9 @@ class ProgressSteps extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    final highContrast = Theme.of(context).brightness == Brightness.dark;
+
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: List.generate(labels.length, (index) {
@@ -23,19 +26,21 @@ class ProgressSteps extends StatelessWidget {
                 height: 29,
                 decoration: BoxDecoration(
                   color: active
-                      ? AppColors.primary
+                      ? colors.primary
                       : complete
-                      ? AppColors.success
-                      : const Color(0xFFF3F4F6),
+                      ? (highContrast ? colors.primary : AppColors.success)
+                      : colors.surfaceContainerHighest,
                   shape: BoxShape.circle,
                 ),
                 alignment: Alignment.center,
                 child: complete
-                    ? const Icon(Icons.check, size: 15, color: Colors.white)
+                    ? Icon(Icons.check, size: 15, color: colors.onPrimary)
                     : Text(
                         '${index + 1}',
                         style: TextStyle(
-                          color: active ? Colors.white : AppColors.muted,
+                          color: active
+                              ? colors.onPrimary
+                              : colors.onSurfaceVariant,
                           fontWeight: FontWeight.w900,
                           fontSize: 12,
                         ),
@@ -45,8 +50,8 @@ class ProgressSteps extends StatelessWidget {
               Text(
                 labels[index],
                 overflow: TextOverflow.ellipsis,
-                style: const TextStyle(
-                  color: AppColors.muted,
+                style: TextStyle(
+                  color: colors.onSurfaceVariant,
                   fontSize: 10,
                   fontWeight: FontWeight.w700,
                 ),

--- a/TP4/lib/core/widgets/section_title.dart
+++ b/TP4/lib/core/widgets/section_title.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 
-import '../theme/app_colors.dart';
-
 class SectionTitle extends StatelessWidget {
   const SectionTitle({
     super.key,
@@ -30,7 +28,7 @@ class SectionTitle extends StatelessWidget {
           TextButton(
             onPressed: onAction,
             style: TextButton.styleFrom(
-              foregroundColor: AppColors.primary,
+              foregroundColor: Theme.of(context).colorScheme.primary,
               padding: const EdgeInsets.symmetric(horizontal: 8),
               visualDensity: VisualDensity.compact,
             ),

--- a/TP4/lib/core/widgets/trip_card.dart
+++ b/TP4/lib/core/widgets/trip_card.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import '../../models/trip.dart';
-import '../theme/app_colors.dart';
 import 'network_image_box.dart';
 import 'pc_badge.dart';
 import 'pc_button.dart';
@@ -24,18 +23,26 @@ class TripCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+    final highContrast = theme.brightness == Brightness.dark;
+
     return Container(
       margin: const EdgeInsets.only(bottom: 14),
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: colors.surfaceContainer,
         borderRadius: BorderRadius.circular(24),
-        border: Border.all(color: const Color(0xFFF3F4F6)),
+        border: Border.all(
+          color: highContrast ? colors.outline : const Color(0xFFF3F4F6),
+          width: highContrast ? 2 : 1,
+        ),
         boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.04),
-            blurRadius: 16,
-            offset: const Offset(0, 8),
-          ),
+          if (!highContrast)
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.04),
+              blurRadius: 16,
+              offset: const Offset(0, 8),
+            ),
         ],
       ),
       clipBehavior: Clip.antiAlias,
@@ -67,7 +74,9 @@ class TripCard extends StatelessWidget {
                 top: 12,
                 right: 12,
                 child: Material(
-                  color: Colors.white.withValues(alpha: 0.92),
+                  color: highContrast
+                      ? colors.surfaceContainerHighest
+                      : Colors.white.withValues(alpha: 0.92),
                   shape: const CircleBorder(),
                   child: InkWell(
                     onTap: onFavorite,
@@ -76,7 +85,9 @@ class TripCard extends StatelessWidget {
                       padding: const EdgeInsets.all(8),
                       child: Icon(
                         isFavorite ? Icons.favorite : Icons.favorite_border,
-                        color: isFavorite ? Colors.redAccent : AppColors.muted,
+                        color: isFavorite
+                            ? (highContrast ? colors.primary : Colors.redAccent)
+                            : colors.onSurfaceVariant,
                         size: 18,
                       ),
                     ),
@@ -122,27 +133,27 @@ class TripCard extends StatelessWidget {
               children: [
                 Row(
                   children: [
-                    const Icon(
+                    Icon(
                       Icons.place_outlined,
-                      color: AppColors.muted,
+                      color: colors.onSurfaceVariant,
                       size: 15,
                     ),
                     const SizedBox(width: 4),
                     Expanded(
                       child: Text(
                         '${trip.origin} -> ${trip.destination}',
-                        style: const TextStyle(
-                          color: AppColors.muted,
+                        style: TextStyle(
+                          color: colors.onSurfaceVariant,
                           fontSize: 12,
                           fontWeight: FontWeight.w600,
                         ),
                       ),
                     ),
-                    const Icon(Icons.star, color: AppColors.accent, size: 15),
+                    Icon(Icons.star, color: colors.primary, size: 15),
                     Text(
                       '${trip.rating}',
-                      style: const TextStyle(
-                        color: Color(0xFFB77900),
+                      style: TextStyle(
+                        color: colors.primary,
                         fontSize: 12,
                         fontWeight: FontWeight.w900,
                       ),
@@ -176,14 +187,14 @@ class TripCard extends StatelessWidget {
                               text: 'R\$ ${trip.price}',
                               style: Theme.of(context).textTheme.titleMedium
                                   ?.copyWith(
-                                    color: AppColors.primary,
+                                    color: colors.primary,
                                     fontSize: 18,
                                   ),
                             ),
-                            const TextSpan(
+                            TextSpan(
                               text: '/pessoa',
                               style: TextStyle(
-                                color: AppColors.muted,
+                                color: colors.onSurfaceVariant,
                                 fontSize: 12,
                               ),
                             ),
@@ -219,17 +230,19 @@ class _Meta extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.onSurfaceVariant;
+
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Icon(icon, color: AppColors.muted, size: 14),
+        Icon(icon, color: color, size: 14),
         const SizedBox(width: 4),
         Flexible(
           child: Text(
             label,
             overflow: TextOverflow.ellipsis,
-            style: const TextStyle(
-              color: AppColors.muted,
+            style: TextStyle(
+              color: color,
               fontSize: 12,
               fontWeight: FontWeight.w600,
             ),

--- a/TP4/lib/features/auth/auth_screens.dart
+++ b/TP4/lib/features/auth/auth_screens.dart
@@ -92,7 +92,7 @@ class _LoginScreenState extends State<LoginScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: SingleChildScrollView(
         child: Column(
           children: [
@@ -373,7 +373,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(
@@ -512,7 +512,7 @@ class _ForgotScreenState extends State<ForgotScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(

--- a/TP4/lib/features/onboarding/onboarding_screens.dart
+++ b/TP4/lib/features/onboarding/onboarding_screens.dart
@@ -148,7 +148,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     final last = _index == _slides.length - 1;
 
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: SafeArea(
         top: false,
         child: Column(
@@ -314,7 +314,7 @@ class _AssistantScreenState extends State<AssistantScreen> {
     ];
 
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           DecoratedBox(

--- a/TP4/lib/features/owner/owner_panel_screen.dart
+++ b/TP4/lib/features/owner/owner_panel_screen.dart
@@ -28,7 +28,7 @@ class _OwnerPanelScreenState extends State<OwnerPanelScreen> {
     final wide = MediaQuery.sizeOf(context).width >= 820;
 
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Row(
         children: [
           if (wide)

--- a/TP4/lib/features/profile/profile_screens.dart
+++ b/TP4/lib/features/profile/profile_screens.dart
@@ -135,9 +135,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
     final profile = _profile;
     final name = profile?.fullName ?? 'Viajante Porto Certo';
     final email = profile?.email ?? _authService.currentUser?.email ?? '';
+    final highContrast = Theme.of(context).brightness == Brightness.dark;
 
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       bottomNavigationBar: PortoBottomNav(
         active: AppScreen.profile,
         nav: widget.nav,
@@ -145,9 +146,11 @@ class _ProfileScreenState extends State<ProfileScreen> {
       body: Column(
         children: [
           DecoratedBox(
-            decoration: const BoxDecoration(
+            decoration: BoxDecoration(
               gradient: LinearGradient(
-                colors: [AppColors.navy, AppColors.primary],
+                colors: highContrast
+                    ? [Colors.black, Colors.black]
+                    : [AppColors.navy, AppColors.primary],
               ),
             ),
             child: SafeArea(
@@ -356,7 +359,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(
@@ -528,7 +531,7 @@ class _ChangePasswordScreenState extends State<ChangePasswordScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(
@@ -652,7 +655,7 @@ class _AccessibilityScreenState extends State<AccessibilityScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(
@@ -688,8 +691,10 @@ class _AccessibilityScreenState extends State<AccessibilityScreen> {
                           ),
                           Text(
                             '${_fontSize.round()}px',
-                            style: const TextStyle(
-                              color: AppColors.muted,
+                            style: TextStyle(
+                              color: Theme.of(
+                                context,
+                              ).colorScheme.onSurfaceVariant,
                               fontWeight: FontWeight.w700,
                             ),
                           ),
@@ -730,16 +735,19 @@ class _AccessibilityScreenState extends State<AccessibilityScreen> {
                   ),
                 ),
                 const SizedBox(height: 14),
-                const PcCard(
+                PcCard(
                   child: Row(
                     children: [
-                      Icon(Icons.info_outline, color: AppColors.primary),
-                      SizedBox(width: 10),
+                      Icon(
+                        Icons.info_outline,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      const SizedBox(width: 10),
                       Expanded(
                         child: Text(
                           'Este app segue WCAG 2.1 Nível AA e é compatível com tecnologias assistivas.',
                           style: TextStyle(
-                            color: AppColors.primary,
+                            color: Theme.of(context).colorScheme.primary,
                             fontWeight: FontWeight.w700,
                             fontSize: 12,
                           ),
@@ -923,7 +931,7 @@ class _HelpScreenState extends State<HelpScreen> {
         .toList();
 
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(
@@ -1078,7 +1086,7 @@ class _GuideScreenState extends State<GuideScreen> {
     final last = _index == content.steps.length - 1;
 
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(
@@ -1275,7 +1283,7 @@ class LegalScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(title: title, backTo: AppScreen.login, nav: nav),
@@ -1491,7 +1499,7 @@ class _SwitchRow extends StatelessWidget {
       contentPadding: EdgeInsets.zero,
       value: value,
       onChanged: onChanged,
-      activeThumbColor: AppColors.primary,
+      activeThumbColor: Theme.of(context).colorScheme.primary,
       title: Text(title, style: const TextStyle(fontWeight: FontWeight.w800)),
       subtitle: Text(subtitle),
     );

--- a/TP4/lib/features/purchase/purchase_screens.dart
+++ b/TP4/lib/features/purchase/purchase_screens.dart
@@ -151,7 +151,7 @@ class _PurchaseScreenState extends State<PurchaseScreen> {
     final arr = stops[_arrivalIndex];
 
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(
@@ -390,7 +390,7 @@ class _AccommodationScreenState extends State<AccommodationScreen> {
     final total = widget.draft.fare + selected.price + widget.draft.serviceFee;
 
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(
@@ -612,7 +612,7 @@ class SummaryScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final trip = draft.trip;
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(
@@ -759,7 +759,7 @@ class _PaymentScreenState extends State<PaymentScreen> {
     ];
 
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(
@@ -927,7 +927,7 @@ class _PixScreenState extends State<PixScreen> {
     final ss = (_seconds % 60).toString().padLeft(2, '0');
 
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(
@@ -1142,7 +1142,7 @@ class _BoletoScreenState extends State<BoletoScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(
@@ -1344,7 +1344,7 @@ class _CreditCardScreenState extends State<CreditCardScreen> {
   Widget build(BuildContext context) {
     if (_processing) return const _ProcessingPaymentScreen();
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(
@@ -1583,7 +1583,7 @@ class _TicketScreenState extends State<TicketScreen> {
 
     if (_cancelled) {
       return Scaffold(
-        backgroundColor: AppColors.surface,
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
         body: Column(
           children: [
             AppHeader(
@@ -1678,7 +1678,7 @@ class _TicketScreenState extends State<TicketScreen> {
     }
 
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(
@@ -1813,7 +1813,7 @@ class _TicketScreenState extends State<TicketScreen> {
     showModalBottomSheet<void>(
       context: context,
       showDragHandle: true,
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
       ),
@@ -2446,22 +2446,24 @@ class _ProcessingPaymentScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      backgroundColor: Colors.white,
+    final colors = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            CircularProgressIndicator(color: AppColors.primary),
-            SizedBox(height: 18),
-            Text(
+            CircularProgressIndicator(color: colors.primary),
+            const SizedBox(height: 18),
+            const Text(
               'Processando pagamento...',
               style: TextStyle(fontWeight: FontWeight.w900),
             ),
-            SizedBox(height: 6),
+            const SizedBox(height: 6),
             Text(
               'Aguarde, estamos verificando seus dados.',
-              style: TextStyle(color: AppColors.muted),
+              style: TextStyle(color: colors.onSurfaceVariant),
             ),
           ],
         ),
@@ -2494,7 +2496,7 @@ class _PaymentResultScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(24),
@@ -2516,7 +2518,10 @@ class _PaymentResultScreen extends StatelessWidget {
               Text(
                 message,
                 textAlign: TextAlign.center,
-                style: const TextStyle(color: AppColors.muted, height: 1.4),
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  height: 1.4,
+                ),
               ),
               const SizedBox(height: 18),
               if (draft != null)
@@ -2595,7 +2600,7 @@ class _BookingTicketScreenState extends State<_BookingTicketScreen> {
     final confirmed = booking.status == 'confirmada';
 
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(

--- a/TP4/lib/features/travel/travel_screens.dart
+++ b/TP4/lib/features/travel/travel_screens.dart
@@ -96,8 +96,11 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    final highContrast = Theme.of(context).brightness == Brightness.dark;
+
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       bottomNavigationBar: PortoBottomNav(
         active: AppScreen.home,
         nav: widget.nav,
@@ -105,11 +108,13 @@ class _HomeScreenState extends State<HomeScreen> {
       body: Column(
         children: [
           DecoratedBox(
-            decoration: const BoxDecoration(
+            decoration: BoxDecoration(
               gradient: LinearGradient(
                 begin: Alignment.topCenter,
                 end: Alignment.bottomCenter,
-                colors: [AppColors.navy, AppColors.primary],
+                colors: highContrast
+                    ? [Colors.black, Colors.black]
+                    : [AppColors.navy, AppColors.primary],
               ),
             ),
             child: SafeArea(
@@ -156,26 +161,31 @@ class _HomeScreenState extends State<HomeScreen> {
                     ),
                     const SizedBox(height: 18),
                     Material(
-                      color: Colors.white,
-                      borderRadius: BorderRadius.circular(18),
-                      elevation: 8,
-                      shadowColor: AppColors.primary.withValues(alpha: 0.25),
+                      color: colors.surfaceContainer,
+                      elevation: highContrast ? 0 : 8,
+                      shadowColor: colors.primary.withValues(alpha: 0.25),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(18),
+                        side: highContrast
+                            ? BorderSide(color: colors.outline, width: 2)
+                            : BorderSide.none,
+                      ),
                       child: InkWell(
                         onTap: () => widget.nav(AppScreen.search),
                         borderRadius: BorderRadius.circular(18),
-                        child: const Padding(
-                          padding: EdgeInsets.symmetric(
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
                             horizontal: 16,
                             vertical: 14,
                           ),
                           child: Row(
                             children: [
-                              Icon(Icons.search, color: AppColors.muted),
-                              SizedBox(width: 12),
+                              Icon(Icons.search, color: colors.primary),
+                              const SizedBox(width: 12),
                               Text(
                                 'Para onde você vai?',
                                 style: TextStyle(
-                                  color: AppColors.muted,
+                                  color: colors.onSurfaceVariant,
                                   fontWeight: FontWeight.w600,
                                 ),
                               ),
@@ -464,7 +474,7 @@ class _SearchScreenState extends State<SearchScreen> {
         : _ports.map((port) => port.city).toSet().toList();
 
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       bottomNavigationBar: PortoBottomNav(
         active: AppScreen.search,
         nav: widget.nav,
@@ -687,7 +697,7 @@ class _ResultsScreenState extends State<ResultsScreen> {
     }).toList();
 
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(
@@ -964,7 +974,7 @@ class _VesselScreenState extends State<VesselScreen> {
   Widget build(BuildContext context) {
     final trip = _trip;
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: CustomScrollView(
         slivers: [
           SliverAppBar(
@@ -1313,7 +1323,7 @@ class _VesselTripsScreenState extends State<VesselTripsScreen> {
   Widget build(BuildContext context) {
     final selectedTrip = widget.selectedTrip;
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(
@@ -1522,7 +1532,7 @@ class _VesselReviewsScreenState extends State<VesselReviewsScreen> {
   Widget build(BuildContext context) {
     final selectedTrip = widget.selectedTrip;
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(
@@ -1700,7 +1710,7 @@ class FavoritesScreen extends StatelessWidget {
         .where((trip) => favoriteIds.contains(trip.id))
         .toList();
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       bottomNavigationBar: PortoBottomNav(
         active: AppScreen.favorites,
         nav: nav,
@@ -1843,7 +1853,7 @@ class _TrackingScreenState extends State<TrackingScreen> {
     final tracking = _tracking;
 
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(
@@ -2162,7 +2172,7 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
     }
 
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(
@@ -2352,7 +2362,7 @@ class _MyTripsScreenState extends State<MyTripsScreen> {
     final list = _active ? activeTrips : history;
 
     return Scaffold(
-      backgroundColor: AppColors.surface,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
           AppHeader(

--- a/TP4/test/app_theme_test.dart
+++ b/TP4/test/app_theme_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:porto_certo_tp4/core/theme/app_colors.dart';
+import 'package:porto_certo_tp4/core/theme/app_theme.dart';
+
+void main() {
+  test('tema padrão preserva a paleta clara', () {
+    final theme = AppTheme.light();
+
+    expect(theme.brightness, Brightness.light);
+    expect(theme.scaffoldBackgroundColor, AppColors.surface);
+    expect(theme.colorScheme.primary, AppColors.primary);
+    expect(theme.bottomNavigationBarTheme.backgroundColor, Colors.white);
+  });
+
+  test('tema de alto contraste usa preto, branco e amarelo', () {
+    final theme = AppTheme.light(highContrast: true);
+
+    expect(theme.brightness, Brightness.dark);
+    expect(theme.scaffoldBackgroundColor, Colors.black);
+    expect(theme.colorScheme.primary, Colors.yellow);
+    expect(theme.colorScheme.onSurface, Colors.white);
+    expect(theme.appBarTheme.backgroundColor, Colors.black);
+    expect(theme.appBarTheme.foregroundColor, Colors.yellow);
+    expect(theme.inputDecorationTheme.fillColor, Colors.black);
+    expect(theme.bottomNavigationBarTheme.backgroundColor, Colors.black);
+    expect(theme.bottomNavigationBarTheme.selectedItemColor, Colors.yellow);
+  });
+}


### PR DESCRIPTION
## Descrição
A preferência `highContrast` é persistida no backend, mas a aplicação ainda nao aplica um tema global de alto contraste em todas as telas. A tela `HighContrastScreen` existe, mas o restante do app continua usando o tema claro padrao.

O objetivo da task é fazer o modo alto contraste afetar o app inteiro quando `_highContrast == true`.


## Tipo de mudança
- [ ] 🐛 Bug fix (correção de falha)
- [x] ✨ Nova feature (nova funcionalidade)
- [ ] ♻️ Refatoração (mudança estrutural sem alterar comportamento)
- [ ] 📝 Atualização de documentação

## Checklist de qualidade:
- [x] Meu código segue os padrões do projeto.
- [] Adicionei testes para cobrir minhas mudanças.
- [x] Todos os testes novos e existentes passaram.
- [ ] A documentação foi atualizada (se necessário).