### PR TITLE
fix: expande cabeçalho da tela de login

### DIFF
--- a/TP4/lib/features/auth/auth_screens.dart
+++ b/TP4/lib/features/auth/auth_screens.dart
@@ -104,32 +104,33 @@ class _LoginScreenState extends State<LoginScreen> {
                   colors: [AppColors.primary, AppColors.secondary],
                 ),
               ),
-              child: SafeArea(
-                bottom: false,
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(24, 20, 24, 42),
-                  child: Column(
-                    children: [
-                      Image.asset(
-                        AppAssets.logo,
-                        width: 142,
-                        height: 142,
-                        fit: BoxFit.contain,
-                      ),
-                      const SizedBox(height: 8),
-                      Text(
-                        'Bem-vindo de volta',
-                        style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                          color: Colors.white,
-                          fontSize: 22,
+              child: SizedBox(
+                width: double.infinity,
+                child: SafeArea(
+                  bottom: false,
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(24, 20, 24, 42),
+                    child: Column(
+                      children: [
+                        Image.asset(
+                          AppAssets.logo,
+                          width: 142,
+                          height: 142,
+                          fit: BoxFit.contain,
                         ),
-                      ),
-                      const SizedBox(height: 6),
-                      const Text(
-                        'Entre na sua conta para continuar',
-                        style: TextStyle(color: Colors.white70, fontSize: 13),
-                      ),
-                    ],
+                        const SizedBox(height: 8),
+                        Text(
+                          'Bem-vindo de volta',
+                          style: Theme.of(context).textTheme.titleLarge
+                              ?.copyWith(color: Colors.white, fontSize: 22),
+                        ),
+                        const SizedBox(height: 6),
+                        const Text(
+                          'Entre na sua conta para continuar',
+                          style: TextStyle(color: Colors.white70, fontSize: 13),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
## Descrição
Na tela de login, o cabeçalho azul não preenchia toda a largura da tela, deixando espaços laterais sem cor na área superior e na barra de status. O problema ocorria porque o DecoratedBox assumia apenas a largura do seu conteúdo. A solução foi definir a largura do cabeçalho como double.infinity, mantendo o gradiente atrás da SafeArea.

## Tipo de mudança
- [x] 🐛 Bug fix (correção de falha)
- [ ] ✨ Nova feature (nova funcionalidade)
- [ ] ♻️ Refatoração (mudança estrutural sem alterar comportamento)
- [ ] 📝 Atualização de documentação

## Checklist de qualidade:
- [x] Meu código segue os padrões do projeto.
- [x] Adicionei testes para cobrir minhas mudanças.
- [x] Todos os testes novos e existentes passaram.
- [ ] A documentação foi atualizada (se necessário).